### PR TITLE
feat: add header product search

### DIFF
--- a/client/src/lib/hooks/use-product-search.tsx
+++ b/client/src/lib/hooks/use-product-search.tsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react"
+import { medusaClient } from "@lib/config"
+import useDebounce from "@lib/hooks/use-debounce"
+import { PricedProduct } from "@medusajs/medusa/dist/types/pricing"
+
+// Custom hook to search products by term
+// Accepts a search term and returns matching products and loading state
+const useProductSearch = (term: string) => {
+  const [results, setResults] = useState<PricedProduct[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+
+  // Debounce term to avoid excessive requests
+  const debouncedTerm = useDebounce(term, 300)
+
+  useEffect(() => {
+    let cancel = false
+
+    const search = async () => {
+      if (!debouncedTerm) {
+        setResults([])
+        return
+      }
+
+      setIsLoading(true)
+      try {
+        const { products } = await medusaClient.products.list({
+          q: debouncedTerm,
+          limit: 5,
+        })
+
+        if (!cancel) {
+          setResults(products)
+        }
+      } catch (e) {
+        if (!cancel) {
+          setResults([])
+        }
+      } finally {
+        if (!cancel) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    search()
+
+    return () => {
+      cancel = true
+    }
+  }, [debouncedTerm])
+
+  return { results, isLoading }
+}
+
+export default useProductSearch

--- a/client/src/modules/layout/templates/nav/index.tsx
+++ b/client/src/modules/layout/templates/nav/index.tsx
@@ -4,7 +4,7 @@ import { useAccount } from "@lib/context/account-context"
 import { useMobileMenu } from "@lib/context/mobile-menu-context"
 import CartDropdown from "@modules/layout/components/cart-dropdown"
 import MobileMenu from "@modules/mobile-menu/templates"
-import DesktopSearchModal from "@modules/search/templates/desktop-search-modal"
+import ProductSearch from "@modules/search/components/product-search"
 import clsx from "clsx"
 import Image from "next/image"
 import { usePathname } from "next/navigation"
@@ -114,8 +114,7 @@ const Nav = () => {
               </div>
 
               <div className="hidden sm:flex ml-4 items-center h-full">
-                <DesktopSearchModal />
-                {/* {process.env.FEATURE_SEARCH_ENABLED && <DesktopSearchModal />} */}
+                <ProductSearch />
               </div>
               <div className="min-w-[350px]">{/* <CountrySelect /> */}</div>
             </div>
@@ -166,7 +165,7 @@ const Nav = () => {
                 </Link>
 
                 {/* <div className="flex sm:hidden">
-            <DesktopSearchModal />
+            <ProductSearch />
           </div> */}
               </div>
             </div>

--- a/client/src/modules/search/components/product-search/index.tsx
+++ b/client/src/modules/search/components/product-search/index.tsx
@@ -1,0 +1,108 @@
+import { useState, useRef, useEffect, KeyboardEvent } from "react"
+import useProductSearch from "@lib/hooks/use-product-search"
+import Thumbnail from "@modules/products/components/thumbnail"
+import Link from "next/link"
+import { useRouter } from "next/navigation"
+import { useTranslation } from "react-i18next"
+
+// Search component displayed in the header.
+// Shows a list of matching products under the input field.
+const ProductSearch = () => {
+  const [term, setTerm] = useState("")
+  const [open, setOpen] = useState(false)
+  const [activeIndex, setActiveIndex] = useState(-1)
+  const containerRef = useRef<HTMLDivElement>(null)
+  const inputRef = useRef<HTMLInputElement>(null)
+  const { results } = useProductSearch(term)
+  const router = useRouter()
+  const { t } = useTranslation("common")
+
+  // Show dropdown when there is a search term
+  useEffect(() => {
+    setOpen(term.length > 0)
+    setActiveIndex(-1)
+  }, [term])
+
+  // Close dropdown on outside click
+  useEffect(() => {
+    const handleClick = (e: MouseEvent) => {
+      if (
+        containerRef.current &&
+        !containerRef.current.contains(e.target as Node)
+      ) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener("mousedown", handleClick)
+    return () => document.removeEventListener("mousedown", handleClick)
+  }, [])
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (!open) return
+
+    if (e.key === "ArrowDown") {
+      e.preventDefault()
+      setActiveIndex((prev) => (prev + 1) % results.length)
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault()
+      setActiveIndex((prev) => (prev - 1 + results.length) % results.length)
+    }
+    if (e.key === "Enter") {
+      const product = results[activeIndex]
+      if (product) {
+        router.push(`/products/${product.handle}`)
+        setOpen(false)
+        setTerm("")
+      }
+    }
+    if (e.key === "Escape") {
+      setOpen(false)
+    }
+  }
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <input
+        ref={inputRef}
+        type="text"
+        value={term}
+        onChange={(e) => setTerm(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={t("search_placeholder", "Buscar productos...")}
+        className="w-full bg-white text-gray-900 rounded-md px-3 py-2 text-sm focus:outline-none"
+      />
+      {open && (
+        <ul className="absolute left-0 right-0 mt-2 bg-white border border-gray-200 rounded-md shadow-lg max-h-80 overflow-auto z-50">
+          {results.length > 0 ? (
+            results.map((product, index) => (
+              <li
+                key={product.id}
+                className={`flex items-center gap-2 p-2 cursor-pointer hover:bg-gray-100 ${
+                  index === activeIndex ? "bg-gray-100" : ""
+                }`}
+              >
+                <Link
+                  href={`/products/${product.handle}`}
+                  className="flex items-center gap-2 w-full"
+                  onClick={() => setOpen(false)}
+                >
+                  <div className="w-10 h-10 flex-shrink-0">
+                    <Thumbnail thumbnail={product.thumbnail} size="bsmall" />
+                  </div>
+                  <span className="text-sm text-gray-900">{product.title}</span>
+                </Link>
+              </li>
+            ))
+          ) : (
+            <li className="p-2 text-sm text-gray-500">
+              {t("no_results", "No hay resultados")}
+            </li>
+          )}
+        </ul>
+      )}
+    </div>
+  )
+}
+
+export default ProductSearch


### PR DESCRIPTION
## Summary
- add debounced `useProductSearch` hook for querying Medusa products
- render searchable product dropdown in header with keyboard navigation

## Testing
- `npm test` (fails: useOrderContext must be used within a CartDropdownProvider)
- `npm run lint` (fails: Failed to load config "next/babel" to extend from.)

------
https://chatgpt.com/codex/tasks/task_e_68bc422074fc83299b49ac55f87b7270